### PR TITLE
Makefile: build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CC=clang
-COPTS=-o x6502 -O3 -lpthread -Wall -lncurses
+CC=gcc
+COPTS=-o x6502 -O3 -Wall
+LIBS=-lncurses -lpthread
 DEBUGOPTS=-DDEBUG -O0 -g
 PYTHON=python
 
@@ -9,7 +10,10 @@ debug-names.h: generate_debug_names.py opcodes.h
 	$(PYTHON) generate_debug_names.py > debug-names.h
 
 release: debug-names.h *.c *.h
-	$(CC) $(COPTS) *.c
+	$(CC) $(COPTS) *.c $(LIBS)
 
 debug: debug-names.h *.c *.h
-	$(CC) $(COPTS) $(DEBUGOPTS) *.c
+	$(CC) $(COPTS) $(DEBUGOPTS) *.c $(LIBS)
+
+clean:
+	rm -f debug-names.h x6502

--- a/README
+++ b/README
@@ -24,7 +24,8 @@ Building and running x6502
     To build x6502, just run `make' in the project root. You
     will need clang and Python installed. To use gcc, change
     the $(CC) var in the Makefile. No libraries beyond POSIX
-    libc are used. This will produce the x6502 binary.
+    libc are used except ncurses. This will produce the
+    x6502 binary.
 
     x6502 takes the compiled 6502 object file as an
     argument, and runs it until it encounters an EXT


### PR DESCRIPTION
I needed to use -l<lib> as a directive and not a flag to make it build on my Ubuntu 18.04.
Could not build it without ncurses also, so I mentioned it in the README.
